### PR TITLE
Add IBTrACS USA wind buffers pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,34 +58,60 @@ Run the ECMWF pipeline for a specific date range:
 python run_pipeline.py ecmwf --start-date 2024-01-01 --end-date 2024-01-07
 ```
 
-### Wind buffers pipeline
+### Wind buffers pipelines
 
-Computes per-storm wind buffer polygons from IBTrACS USA quadrant wind radii (34/50/64 kt) and stores them in the database. Reads track data from the PROD database and writes buffers to the target environment (default: `dev`).
+Two pipelines compute wind buffer polygons from quadrant wind radii (34/50/64 kt) and store them in the database. Both read from PROD and write to the target environment (default: `dev`), and both require `PGSSLMODE=require`:
 
-Requires the `usa-wind-buffers` branch of `ocha-lens` to be installed (provides `calculate_wind_buffers_gdf` and `expand_quad_col`). Run the IBTrACS pipeline first to populate `storms.ibtracs_tracks_geo`.
-
-Also requires `PGSSLMODE=require` to be set (Azure PostgreSQL requires SSL):
 ```
 export PGSSLMODE=require
 ```
+
+Both require the `usa-wind-buffers` branch of `ocha-lens` (provides `calculate_wind_buffers_gdf` and `expand_quad_col`). Buffers are written to the DB in batches of 50 as they are calculated, so a crash mid-run is recoverable — just rerun and it will skip already-computed entries.
+
+#### IBTrACS wind buffers (`wind-buffers`)
+
+One buffer polygon per (storm, wind speed threshold) across the full historical track. Uses USA agency quadrant radii from `storms.ibtracs_tracks_geo`. Run the IBTrACS pipeline first.
 
 ```
 python run_pipeline.py wind-buffers [OPTIONS]
 ```
 
 Options:
-- `--mode {dev,prod}`: Target database environment for writing buffers (default: `dev`). Always reads from PROD.
+- `--mode {dev,prod}`: Target database environment (default: `dev`). Always reads from PROD.
 - `--basin CODE`: Filter to a single basin (e.g. `NA`, `WP`, `EP`, `SI`, `SP`, `NI`, `SA`)
 - `--start-year YYYY`: Only process storms with track points from this year onwards
-- `--chunksize N`: Number of records per SQL insert batch (default: `1000`)
+- `--overwrite`: Recalculate even for storms already in the database
+- `--chunksize N`: Rows per SQL insert batch (default: `1000`)
 
-Examples:
-```
+```bash
 # Full historical backfill
 python run_pipeline.py wind-buffers --mode dev
 
 # Subset for testing
 python run_pipeline.py wind-buffers --mode dev --basin NA --start-year 2020
+```
+
+#### NHC forecast wind buffers (`nhc-wind-buffers`)
+
+One buffer polygon per (storm, forecast issuance, wind speed threshold) from NHC forecast tracks. Uses `storms.nhc_tracks_geo`. Run the NHC pipeline first.
+
+```
+python run_pipeline.py nhc-wind-buffers [OPTIONS]
+```
+
+Options:
+- `--mode {dev,prod}`: Target database environment (default: `dev`). Always reads from PROD.
+- `--basin {NA,EP}`: Filter to a single basin
+- `--start-year YYYY`: Only process issuances from this year onwards
+- `--overwrite`: Recalculate even for issuances already in the database
+- `--chunksize N`: Rows per SQL insert batch (default: `1000`)
+
+```bash
+# Full historical backfill
+python run_pipeline.py nhc-wind-buffers --mode dev
+
+# Subset for testing
+python run_pipeline.py nhc-wind-buffers --mode dev --basin NA --start-year 2023
 ```
 
 ### Note on backfilling
@@ -198,10 +224,31 @@ One row per (storm, wind speed threshold). Populated by the wind-buffers pipelin
 The buffers use USA agency quadrant radii and basin-appropriate map projections to correctly handle storms near the antimeridian (WP, SP, EP basins).
 
 ### `storms.nhc_storms`
-One row per NHC storm. Primary key: `atcf_id`.
+One row per NHC storm. Primary key: `atcf_id` (e.g. `AL092023`). Only covers NA and EP basins.
 
 ### `storms.nhc_tracks_geo`
-One row per NHC forecast point (observations at leadtime=0, forecasts at leadtime>0). Includes `quadrant_radius_34/50/64` columns (JSON arrays).
+One row per NHC forecast point. Populated by the NHC pipeline.
+
+| Column | Type | Description |
+|---|---|---|
+| `atcf_id` | VARCHAR | FK → nhc_storms |
+| `issued_time` | TIMESTAMP | When the forecast was issued (UTC) |
+| `valid_time` | TIMESTAMP | Forecast valid time (UTC) |
+| `leadtime` | INTEGER | Hours ahead of issuance (0 = observation) |
+| `basin` | VARCHAR | NA or EP |
+| `wind_speed` | REAL | Max sustained wind speed (knots) |
+| `quadrant_radius_34/50/64` | TEXT | JSON array `[NE, SE, SW, NW]` — wind radii (nm) |
+| `geometry` | geometry(Point, 4326) | Forecast track point location |
+
+### `storms.nhc_wind_buffers`
+One row per (storm, forecast issuance, wind speed threshold). Populated by the `nhc-wind-buffers` pipeline. Depends on `nhc_tracks_geo` being populated first.
+
+| Column | Type | Description |
+|---|---|---|
+| `atcf_id` | VARCHAR | ATCF storm identifier |
+| `issued_time` | TIMESTAMP | Forecast issuance time (UTC) |
+| `wind_speed_kt` | SMALLINT | Wind speed threshold: 34, 50, or 64 knots |
+| `geometry` | geometry(Geometry, 4326) | Union of wind buffer discs across the forecast track. Polygon or MultiPolygon. |
 
 ### `storms.nhc_wsp_polygon` *(pending — `add-wsp-data` PR)*
 Basin-wide NHC wind speed probability polygons. One row per (issued_time, wind_threshold_kt, percentage band).

--- a/README.md
+++ b/README.md
@@ -58,6 +58,36 @@ Run the ECMWF pipeline for a specific date range:
 python run_pipeline.py ecmwf --start-date 2024-01-01 --end-date 2024-01-07
 ```
 
+### Wind buffers pipeline
+
+Computes per-storm wind buffer polygons from IBTrACS USA quadrant wind radii (34/50/64 kt) and stores them in the database. Reads track data from the PROD database and writes buffers to the target environment (default: `dev`).
+
+Requires the `usa-wind-buffers` branch of `ocha-lens` to be installed (provides `calculate_wind_buffers_gdf` and `expand_quad_col`). Run the IBTrACS pipeline first to populate `storms.ibtracs_tracks_geo`.
+
+Also requires `PGSSLMODE=require` to be set (Azure PostgreSQL requires SSL):
+```
+export PGSSLMODE=require
+```
+
+```
+python run_pipeline.py wind-buffers [OPTIONS]
+```
+
+Options:
+- `--mode {dev,prod}`: Target database environment for writing buffers (default: `dev`). Always reads from PROD.
+- `--basin CODE`: Filter to a single basin (e.g. `NA`, `WP`, `EP`, `SI`, `SP`, `NI`, `SA`)
+- `--start-year YYYY`: Only process storms with track points from this year onwards
+- `--chunksize N`: Number of records per SQL insert batch (default: `1000`)
+
+Examples:
+```
+# Full historical backfill
+python run_pipeline.py wind-buffers --mode dev
+
+# Subset for testing
+python run_pipeline.py wind-buffers --mode dev --basin NA --start-year 2020
+```
+
 ### Note on backfilling
 
 These pipelines do not support automated backfilling. Unlike datasets with regular update schedules, cyclone data is published based on storm activity rather than a fixed cadence. When historical data needs to be reprocessed, it should be done manually using the appropriate date ranges or dataset types.
@@ -126,3 +156,52 @@ python run_pipeline.py nhc --start-year 2023
 python run_pipeline.py nhc --start-year 2020 --end-year 2024
 ```
 
+## Database schema
+
+All tables live in the `storms` schema. The pipeline reads from PROD and writes to DEV by default.
+
+### `storms.ibtracs_storms`
+One row per storm. Primary key: `sid` (IBTrACS serial ID).
+
+| Column | Type | Description |
+|---|---|---|
+| `sid` | VARCHAR | IBTrACS serial identifier (e.g. `2023249N12323`) |
+| `atcf_id` | VARCHAR | ATCF identifier (e.g. `AL092023`) |
+| `name` | VARCHAR | Storm name (uppercase) |
+| `season` | BIGINT | Season year |
+| `genesis_basin` | VARCHAR | Basin where storm originated (NA, WP, EP, SI, SP, NI, SA) |
+| `provisional` | BOOLEAN | Whether data is provisional (not yet finalized in IBTrACS) |
+| `storm_id` | VARCHAR | Standardized ID: `{name}_{basin}_{season}` (lowercase) |
+
+### `storms.ibtracs_tracks_geo`
+One row per observation point. Populated by the IBTrACS pipeline.
+
+| Column | Type | Description |
+|---|---|---|
+| `sid` | VARCHAR | FK → ibtracs_storms |
+| `valid_time` | TIMESTAMP | Observation time (UTC) |
+| `basin` | VARCHAR | Current basin at this point |
+| `wind_speed` | INTEGER | Max sustained wind speed (knots) |
+| `quadrant_radius_34/50/64` | TEXT | JSON array `[NE, SE, SW, NW]` — WMO best-track wind radii (nm) |
+| `usa_quadrant_radius_34/50/64` | TEXT | JSON array `[NE, SE, SW, NW]` — USA agency wind radii (nm), available ~2004+ |
+| `geometry` | geometry(Point, 4326) | Track point location |
+
+### `storms.ibtracs_wind_buffers`
+One row per (storm, wind speed threshold). Populated by the wind-buffers pipeline. Depends on `ibtracs_tracks_geo` being populated first.
+
+| Column | Type | Description |
+|---|---|---|
+| `sid` | VARCHAR | IBTrACS storm ID |
+| `wind_speed_kt` | SMALLINT | Wind speed threshold: 34, 50, or 64 knots |
+| `geometry` | geometry(Geometry, 4326) | Union of all wind buffer discs along the storm track. Polygon or MultiPolygon (antimeridian-crossing storms are split at ±180°) |
+
+The buffers use USA agency quadrant radii and basin-appropriate map projections to correctly handle storms near the antimeridian (WP, SP, EP basins).
+
+### `storms.nhc_storms`
+One row per NHC storm. Primary key: `atcf_id`.
+
+### `storms.nhc_tracks_geo`
+One row per NHC forecast point (observations at leadtime=0, forecasts at leadtime>0). Includes `quadrant_radius_34/50/64` columns (JSON arrays).
+
+### `storms.nhc_wsp_polygon` *(pending — `add-wsp-data` PR)*
+Basin-wide NHC wind speed probability polygons. One row per (issued_time, wind_threshold_kt, percentage band).

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from src.pipelines.ecmwf import run_ecmwf
 from src.pipelines.ibtracs import run_ibtracs
 from src.pipelines.nhc import run_nhc_current, run_nhc_archive
+from src.pipelines.wind_buffers import run_wind_buffers
 
 
 def main():
@@ -87,6 +88,22 @@ def main():
         help="End year for archive processing (e.g., 2024). If not provided, only processes start-year.",
     )
 
+    # Wind buffers subparser
+    wind_buffers_parser = subparsers.add_parser(
+        "wind-buffers",
+        parents=[common],
+        help="Run IBTrACS wind buffers pipeline (reads PROD tracks, writes DEV buffers)",
+    )
+    wind_buffers_parser.add_argument(
+        "--basin",
+        help="Filter to a single basin (e.g. NA, WP, EP)",
+    )
+    wind_buffers_parser.add_argument(
+        "--start-year",
+        type=int,
+        help="Only process storms with track points from this year onwards",
+    )
+
     args = parser.parse_args()
 
     if args.pipeline == "ibtracs":
@@ -126,6 +143,13 @@ def main():
                 save_dir=args.save_dir,
                 chunksize=args.chunksize,
             )
+    elif args.pipeline == "wind-buffers":
+        run_wind_buffers(
+            write_mode=args.mode,
+            chunksize=args.chunksize,
+            basin=args.basin,
+            start_year=args.start_year,
+        )
 
 
 if __name__ == "__main__":

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -103,6 +103,11 @@ def main():
         type=int,
         help="Only process storms with track points from this year onwards",
     )
+    wind_buffers_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Recalculate buffers even for storms already in the database",
+    )
 
     args = parser.parse_args()
 
@@ -149,6 +154,7 @@ def main():
             chunksize=args.chunksize,
             basin=args.basin,
             start_year=args.start_year,
+            overwrite=args.overwrite,
         )
 
 

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from src.pipelines.ecmwf import run_ecmwf
 from src.pipelines.ibtracs import run_ibtracs
 from src.pipelines.nhc import run_nhc_current, run_nhc_archive
-from src.pipelines.wind_buffers import run_wind_buffers
+from src.pipelines.wind_buffers import run_nhc_wind_buffers, run_wind_buffers
 
 
 def main():
@@ -109,6 +109,27 @@ def main():
         help="Recalculate buffers even for storms already in the database",
     )
 
+    # NHC wind buffers subparser
+    nhc_wind_buffers_parser = subparsers.add_parser(
+        "nhc-wind-buffers",
+        parents=[common],
+        help="Run NHC forecast wind buffers pipeline (reads PROD tracks, writes DEV buffers)",
+    )
+    nhc_wind_buffers_parser.add_argument(
+        "--basin",
+        help="Filter to a single basin (e.g. NA, EP)",
+    )
+    nhc_wind_buffers_parser.add_argument(
+        "--start-year",
+        type=int,
+        help="Only process issuances from this year onwards",
+    )
+    nhc_wind_buffers_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Recalculate buffers even for issuances already in the database",
+    )
+
     args = parser.parse_args()
 
     if args.pipeline == "ibtracs":
@@ -150,6 +171,14 @@ def main():
             )
     elif args.pipeline == "wind-buffers":
         run_wind_buffers(
+            write_mode=args.mode,
+            chunksize=args.chunksize,
+            basin=args.basin,
+            start_year=args.start_year,
+            overwrite=args.overwrite,
+        )
+    elif args.pipeline == "nhc-wind-buffers":
+        run_nhc_wind_buffers(
             write_mode=args.mode,
             chunksize=args.chunksize,
             basin=args.basin,

--- a/src/pipelines/wind_buffers.py
+++ b/src/pipelines/wind_buffers.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+IBTrACS wind buffer pipeline.
+
+Reads track data from storms.ibtracs_tracks_geo (PROD), computes per-storm
+wind buffer polygons using ocha-lens, and writes to storms.ibtracs_wind_buffers (DEV).
+"""
+
+import logging
+import warnings
+
+import coloredlogs
+import geopandas as gpd
+import pandas as pd
+from dotenv import load_dotenv
+from ocha_lens.utils.storm import calculate_wind_buffers_gdf, expand_quad_col
+from tqdm import tqdm
+
+load_dotenv()
+
+import ocha_stratus as stratus  # noqa
+
+BUFFER_SPEEDS = [34, 50, 64]
+logger = logging.getLogger(__name__)
+
+
+def load_tracks(
+    engine,
+    basin: str = None,
+    start_year: int = None,
+) -> gpd.GeoDataFrame:
+    filters = [
+        """(usa_quadrant_radius_34 IS NOT NULL
+            OR usa_quadrant_radius_50 IS NOT NULL
+            OR usa_quadrant_radius_64 IS NOT NULL)"""
+    ]
+    if basin:
+        filters.append(f"basin = '{basin}'")
+    if start_year:
+        filters.append(f"EXTRACT(YEAR FROM valid_time) >= {start_year}")
+
+    where = " AND ".join(filters)
+    query = f"""
+        SELECT sid, basin, valid_time,
+               usa_quadrant_radius_34,
+               usa_quadrant_radius_50,
+               usa_quadrant_radius_64,
+               geometry
+        FROM storms.ibtracs_tracks_geo
+        WHERE {where}
+        ORDER BY sid, valid_time
+    """
+    with engine.connect() as conn:
+        return gpd.read_postgis(query, conn, geom_col="geometry")
+
+
+def process_wind_buffers(read_engine, write_engine, chunksize, basin=None, start_year=None):
+    logger.info("Loading IBTrACS tracks with USA wind radii from PROD...")
+    gdf_tracks = load_tracks(read_engine, basin=basin, start_year=start_year)
+    logger.info(
+        f"Loaded {len(gdf_tracks)} track points "
+        f"across {gdf_tracks['sid'].nunique()} storms."
+    )
+
+    logger.info("Expanding quadrant radius columns...")
+    for speed in BUFFER_SPEEDS:
+        gdf_tracks = expand_quad_col(gdf_tracks, f"usa_quadrant_radius_{speed}")
+
+    logger.info("Calculating wind buffers per storm...")
+    results = []
+    for sid, group in tqdm(gdf_tracks.groupby("sid")):
+        gdf_buffers = calculate_wind_buffers_gdf(group)
+        gdf_buffers["sid"] = sid
+        results.append(gdf_buffers)
+
+    gdf_all = pd.concat(results, ignore_index=True)
+    gdf_all = gdf_all.rename(columns={"speed": "wind_speed_kt"})
+    logger.info(f"Calculated {len(gdf_all)} buffer polygons.")
+
+    logger.info("Writing wind buffers to DEV database...")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message="Geometry column does not contain geometry"
+        )
+        gdf_all["geometry"] = gdf_all["geometry"].apply(
+            lambda g: g.wkt if g is not None else None
+        )
+
+    with write_engine.connect() as conn:
+        gdf_all[["sid", "wind_speed_kt", "geometry"]].to_sql(
+            name="ibtracs_wind_buffers",
+            con=conn,
+            schema="storms",
+            if_exists="append",
+            index=False,
+            method=stratus.postgres_upsert,
+            chunksize=chunksize,
+        )
+    logger.info("Successfully wrote wind buffers.")
+
+
+def run_wind_buffers(write_mode="dev", chunksize=1000, basin=None, start_year=None):
+    coloredlogs.install(
+        logger=logger,
+        fmt="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    logger.info("Starting IBTrACS wind buffers pipeline...")
+    read_engine = stratus.get_engine(stage="prod")
+    write_engine = stratus.get_engine(stage=write_mode, write=True)
+    try:
+        process_wind_buffers(
+            read_engine=read_engine,
+            write_engine=write_engine,
+            chunksize=chunksize,
+            basin=basin,
+            start_year=start_year,
+        )
+        logger.info("Pipeline successfully finished!")
+    except Exception as e:
+        logger.error(f"An error occurred: {e}", exc_info=True)
+        raise

--- a/src/pipelines/wind_buffers.py
+++ b/src/pipelines/wind_buffers.py
@@ -64,6 +64,30 @@ def load_existing_sids(engine) -> set:
         return {row[0] for row in result}
 
 
+def _write_batch(batch, conn, table, cols, chunksize):
+    gdf = pd.concat(batch, ignore_index=True).rename(columns={"speed": "wind_speed_kt"})
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message="Geometry column does not contain geometry"
+        )
+        gdf["geometry"] = gdf["geometry"].apply(
+            lambda g: g.wkt if g is not None else None
+        )
+    gdf[cols].to_sql(
+        name=table,
+        con=conn,
+        schema="storms",
+        if_exists="append",
+        index=False,
+        method=stratus.postgres_upsert,
+        chunksize=chunksize,
+    )
+    conn.commit()
+
+
+WRITE_BATCH_SIZE = 50
+
+
 def process_wind_buffers(
     read_engine, write_engine, chunksize, basin=None, start_year=None, overwrite=False
 ):
@@ -92,40 +116,124 @@ def process_wind_buffers(
     for speed in BUFFER_SPEEDS:
         gdf_tracks = expand_quad_col(gdf_tracks, f"usa_quadrant_radius_{speed}")
 
-    logger.info("Calculating wind buffers per storm...")
-    results = []
-    for sid, group in tqdm(gdf_tracks.groupby("sid")):
-        gdf_buffers = calculate_wind_buffers_gdf(group)
-        gdf_buffers["sid"] = sid
-        results.append(gdf_buffers)
-
-    gdf_all = pd.concat(results, ignore_index=True)
-    gdf_all = gdf_all.rename(columns={"speed": "wind_speed_kt"})
-    logger.info(f"Calculated {len(gdf_all)} buffer polygons.")
-
-    logger.info("Writing wind buffers to DEV database...")
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore", message="Geometry column does not contain geometry"
-        )
-        gdf_all["geometry"] = gdf_all["geometry"].apply(
-            lambda g: g.wkt if g is not None else None
-        )
-
+    logger.info("Calculating and writing wind buffers per storm...")
+    cols = ["sid", "wind_speed_kt", "geometry"]
+    batch = []
     with write_engine.connect() as conn:
-        gdf_all[["sid", "wind_speed_kt", "geometry"]].to_sql(
-            name="ibtracs_wind_buffers",
-            con=conn,
-            schema="storms",
-            if_exists="append",
-            index=False,
-            method=stratus.postgres_upsert,
-            chunksize=chunksize,
-        )
+        for sid, group in tqdm(gdf_tracks.groupby("sid")):
+            gdf_buffers = calculate_wind_buffers_gdf(group)
+            gdf_buffers["sid"] = sid
+            batch.append(gdf_buffers)
+
+            if len(batch) >= WRITE_BATCH_SIZE:
+                _write_batch(batch, conn, "ibtracs_wind_buffers", cols, chunksize)
+                batch = []
+
+        if batch:
+            _write_batch(batch, conn, "ibtracs_wind_buffers", cols, chunksize)
+
     logger.info("Successfully wrote wind buffers.")
 
 
-def run_wind_buffers(write_mode="dev", chunksize=1000, basin=None, start_year=None, overwrite=False):
+def load_nhc_tracks(
+    engine,
+    basin: str = None,
+    start_year: int = None,
+) -> gpd.GeoDataFrame:
+    filters = [
+        """(quadrant_radius_34 IS NOT NULL
+            OR quadrant_radius_50 IS NOT NULL
+            OR quadrant_radius_64 IS NOT NULL)"""
+    ]
+    if basin:
+        filters.append(f"basin = '{basin}'")
+    if start_year:
+        filters.append(f"EXTRACT(YEAR FROM issued_time) >= {start_year}")
+
+    where = " AND ".join(filters)
+    query = f"""
+        SELECT atcf_id, basin, issued_time, valid_time,
+               quadrant_radius_34,
+               quadrant_radius_50,
+               quadrant_radius_64,
+               geometry
+        FROM storms.nhc_tracks_geo
+        WHERE {where}
+        ORDER BY atcf_id, issued_time, valid_time
+    """
+    with engine.connect() as conn:
+        return gpd.read_postgis(query, conn, geom_col="geometry")
+
+
+def load_existing_nhc_keys(engine) -> set:
+    from sqlalchemy import text
+
+    with engine.connect() as conn:
+        result = conn.execute(
+            text("SELECT DISTINCT atcf_id, issued_time FROM storms.nhc_wind_buffers")
+        )
+        return {(row[0], row[1]) for row in result}
+
+
+def process_nhc_wind_buffers(
+    read_engine, write_engine, chunksize, basin=None, start_year=None, overwrite=False
+):
+    logger.info("Loading NHC tracks with wind radii from PROD...")
+    gdf_tracks = load_nhc_tracks(read_engine, basin=basin, start_year=start_year)
+    n_issuances = gdf_tracks.groupby(["atcf_id", "issued_time"]).ngroups
+    logger.info(
+        f"Loaded {len(gdf_tracks)} track points across "
+        f"{gdf_tracks['atcf_id'].nunique()} storms, {n_issuances} forecast issuances."
+    )
+
+    if not overwrite:
+        existing = load_existing_nhc_keys(write_engine)
+        if existing:
+            before = gdf_tracks.groupby(["atcf_id", "issued_time"]).ngroups
+            mask = gdf_tracks.apply(
+                lambda r: (r["atcf_id"], r["issued_time"]) not in existing, axis=1
+            )
+            gdf_tracks = gdf_tracks[mask]
+            after = gdf_tracks.groupby(["atcf_id", "issued_time"]).ngroups if not gdf_tracks.empty else 0
+            logger.info(
+                f"Skipping {before - after} already-computed issuances. "
+                f"{after} remaining."
+            )
+        if gdf_tracks.empty:
+            logger.info("All issuances already computed. Nothing to do.")
+            return
+
+    logger.info("Expanding quadrant radius columns...")
+    for speed in BUFFER_SPEEDS:
+        gdf_tracks = expand_quad_col(gdf_tracks, f"quadrant_radius_{speed}")
+
+    logger.info("Calculating and writing wind buffers per forecast issuance...")
+    cols = ["atcf_id", "issued_time", "wind_speed_kt", "geometry"]
+    batch = []
+    with write_engine.connect() as conn:
+        for (atcf_id, issued_time), group in tqdm(
+            gdf_tracks.groupby(["atcf_id", "issued_time"])
+        ):
+            gdf_buffers = calculate_wind_buffers_gdf(
+                group, quad_cols_format="quadrant_radius_{speed}_{quad}"
+            )
+            gdf_buffers["atcf_id"] = atcf_id
+            gdf_buffers["issued_time"] = issued_time
+            batch.append(gdf_buffers)
+
+            if len(batch) >= WRITE_BATCH_SIZE:
+                _write_batch(batch, conn, "nhc_wind_buffers", cols, chunksize)
+                batch = []
+
+        if batch:
+            _write_batch(batch, conn, "nhc_wind_buffers", cols, chunksize)
+
+    logger.info("Successfully wrote NHC wind buffers.")
+
+
+def run_wind_buffers(
+    write_mode="dev", chunksize=1000, basin=None, start_year=None, overwrite=False
+):
     coloredlogs.install(
         logger=logger,
         fmt="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -135,6 +243,31 @@ def run_wind_buffers(write_mode="dev", chunksize=1000, basin=None, start_year=No
     write_engine = stratus.get_engine(stage=write_mode, write=True)
     try:
         process_wind_buffers(
+            read_engine=read_engine,
+            write_engine=write_engine,
+            chunksize=chunksize,
+            basin=basin,
+            start_year=start_year,
+            overwrite=overwrite,
+        )
+        logger.info("Pipeline successfully finished!")
+    except Exception as e:
+        logger.error(f"An error occurred: {e}", exc_info=True)
+        raise
+
+
+def run_nhc_wind_buffers(
+    write_mode="dev", chunksize=1000, basin=None, start_year=None, overwrite=False
+):
+    coloredlogs.install(
+        logger=logger,
+        fmt="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    logger.info("Starting NHC wind buffers pipeline...")
+    read_engine = stratus.get_engine(stage="prod")
+    write_engine = stratus.get_engine(stage=write_mode, write=True)
+    try:
+        process_nhc_wind_buffers(
             read_engine=read_engine,
             write_engine=write_engine,
             chunksize=chunksize,

--- a/src/pipelines/wind_buffers.py
+++ b/src/pipelines/wind_buffers.py
@@ -54,13 +54,39 @@ def load_tracks(
         return gpd.read_postgis(query, conn, geom_col="geometry")
 
 
-def process_wind_buffers(read_engine, write_engine, chunksize, basin=None, start_year=None):
+def load_existing_sids(engine) -> set:
+    from sqlalchemy import text
+
+    with engine.connect() as conn:
+        result = conn.execute(
+            text("SELECT DISTINCT sid FROM storms.ibtracs_wind_buffers")
+        )
+        return {row[0] for row in result}
+
+
+def process_wind_buffers(
+    read_engine, write_engine, chunksize, basin=None, start_year=None, overwrite=False
+):
     logger.info("Loading IBTrACS tracks with USA wind radii from PROD...")
     gdf_tracks = load_tracks(read_engine, basin=basin, start_year=start_year)
     logger.info(
         f"Loaded {len(gdf_tracks)} track points "
         f"across {gdf_tracks['sid'].nunique()} storms."
     )
+
+    if not overwrite:
+        existing = load_existing_sids(write_engine)
+        if existing:
+            before = gdf_tracks["sid"].nunique()
+            gdf_tracks = gdf_tracks[~gdf_tracks["sid"].isin(existing)]
+            skipped = before - gdf_tracks["sid"].nunique()
+            logger.info(
+                f"Skipping {skipped} already-computed storms. "
+                f"{gdf_tracks['sid'].nunique()} remaining."
+            )
+        if gdf_tracks.empty:
+            logger.info("All storms already computed. Nothing to do.")
+            return
 
     logger.info("Expanding quadrant radius columns...")
     for speed in BUFFER_SPEEDS:
@@ -99,7 +125,7 @@ def process_wind_buffers(read_engine, write_engine, chunksize, basin=None, start
     logger.info("Successfully wrote wind buffers.")
 
 
-def run_wind_buffers(write_mode="dev", chunksize=1000, basin=None, start_year=None):
+def run_wind_buffers(write_mode="dev", chunksize=1000, basin=None, start_year=None, overwrite=False):
     coloredlogs.install(
         logger=logger,
         fmt="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -114,6 +140,7 @@ def run_wind_buffers(write_mode="dev", chunksize=1000, basin=None, start_year=No
             chunksize=chunksize,
             basin=basin,
             start_year=start_year,
+            overwrite=overwrite,
         )
         logger.info("Pipeline successfully finished!")
     except Exception as e:

--- a/src/schemas/sql/ibtracs_wind_buffers.sql
+++ b/src/schemas/sql/ibtracs_wind_buffers.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- IBTrACS wind buffer polygons schema
+-- ============================================================================
+-- One row per (sid, wind_speed_kt): the union of all wind buffer discs along
+-- the storm track at that wind speed threshold.
+--
+-- Populated by running: python run_pipeline.py wind-buffers
+-- Reads tracks from PROD storms.ibtracs_tracks_geo, writes here (DEV).
+-- ============================================================================
+
+-- DROP TABLE IF EXISTS storms.ibtracs_wind_buffers CASCADE;
+
+CREATE TABLE IF NOT EXISTS storms.ibtracs_wind_buffers
+(
+    sid           VARCHAR  NOT NULL,
+    wind_speed_kt SMALLINT NOT NULL CHECK (wind_speed_kt IN (34, 50, 64)),
+    geometry      geometry(Geometry, 4326),
+    CONSTRAINT ibtracs_wind_buffers_unique UNIQUE (sid, wind_speed_kt)
+)
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS storms.ibtracs_wind_buffers
+    OWNER to {owner};
+
+COMMENT ON TABLE storms.ibtracs_wind_buffers IS
+    'Per-storm wind buffer polygons derived from IBTrACS USA quadrant wind radii';
+COMMENT ON COLUMN storms.ibtracs_wind_buffers.sid IS
+    'IBTrACS serial identifier - foreign key to ibtracs_storms';
+COMMENT ON COLUMN storms.ibtracs_wind_buffers.wind_speed_kt IS
+    'Wind speed threshold in knots (34, 50, or 64)';
+COMMENT ON COLUMN storms.ibtracs_wind_buffers.geometry IS
+    'Union of all wind buffer discs along the storm track in WGS84 (EPSG:4326). '
+    'May be Polygon or MultiPolygon (e.g. for antimeridian-crossing storms).';
+
+-- ============================================================================
+-- Indexes
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_ibtracs_wind_buffers_geometry
+    ON storms.ibtracs_wind_buffers USING gist (geometry)
+    TABLESPACE pg_default;
+
+CREATE INDEX IF NOT EXISTS idx_ibtracs_wind_buffers_sid
+    ON storms.ibtracs_wind_buffers (sid)
+    TABLESPACE pg_default;

--- a/src/schemas/sql/nhc_wind_buffers.sql
+++ b/src/schemas/sql/nhc_wind_buffers.sql
@@ -1,0 +1,52 @@
+-- ============================================================================
+-- NHC forecast wind buffer polygons schema
+-- ============================================================================
+-- One row per (atcf_id, issued_time, wind_speed_kt): the union of all wind
+-- buffer discs across the forecast track for that issuance.
+--
+-- Populated by running: python run_pipeline.py nhc-wind-buffers
+-- Reads from PROD storms.nhc_tracks_geo, writes here (DEV).
+-- ============================================================================
+
+-- DROP TABLE IF EXISTS storms.nhc_wind_buffers CASCADE;
+
+CREATE TABLE IF NOT EXISTS storms.nhc_wind_buffers
+(
+    atcf_id       VARCHAR   NOT NULL,
+    issued_time   TIMESTAMP NOT NULL,
+    wind_speed_kt SMALLINT  NOT NULL CHECK (wind_speed_kt IN (34, 50, 64)),
+    geometry      geometry(Geometry, 4326),
+    CONSTRAINT nhc_wind_buffers_unique UNIQUE (atcf_id, issued_time, wind_speed_kt)
+)
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS storms.nhc_wind_buffers
+    OWNER to {owner};
+
+COMMENT ON TABLE storms.nhc_wind_buffers IS
+    'Per-forecast wind buffer polygons derived from NHC quadrant wind radii';
+COMMENT ON COLUMN storms.nhc_wind_buffers.atcf_id IS
+    'ATCF storm identifier (e.g. AL092023) - links to nhc_storms';
+COMMENT ON COLUMN storms.nhc_wind_buffers.issued_time IS
+    'Forecast issuance time (UTC)';
+COMMENT ON COLUMN storms.nhc_wind_buffers.wind_speed_kt IS
+    'Wind speed threshold in knots (34, 50, or 64)';
+COMMENT ON COLUMN storms.nhc_wind_buffers.geometry IS
+    'Union of wind buffer discs across the full forecast track in WGS84 (EPSG:4326). '
+    'May be Polygon or MultiPolygon.';
+
+-- ============================================================================
+-- Indexes
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_nhc_wind_buffers_geometry
+    ON storms.nhc_wind_buffers USING gist (geometry)
+    TABLESPACE pg_default;
+
+CREATE INDEX IF NOT EXISTS idx_nhc_wind_buffers_atcf_id
+    ON storms.nhc_wind_buffers (atcf_id)
+    TABLESPACE pg_default;
+
+CREATE INDEX IF NOT EXISTS idx_nhc_wind_buffers_issued_time
+    ON storms.nhc_wind_buffers (issued_time)
+    TABLESPACE pg_default;


### PR DESCRIPTION
## Summary

- Adds `storms.ibtracs_wind_buffers` table (one row per storm per wind speed threshold: 34/50/64 kt)
- New pipeline `src/pipelines/wind_buffers.py` reads USA quadrant wind radii from PROD `ibtracs_tracks_geo`, calls `ocha-lens` buffer calculation functions, and writes to DEV
- Registered as `wind-buffers` subcommand in `run_pipeline.py` with optional `--basin` and `--start-year` filters

Depends on the `usa-wind-buffers` PR in ocha-lens being merged first (for `calculate_wind_buffers_gdf` and `expand_quad_col`).

## Usage

```bash
# Full historical run
python run_pipeline.py wind-buffers --mode dev

# Subset (e.g. for testing)
python run_pipeline.py wind-buffers --mode dev --basin NA --start-year 2020
```

## Test plan

- [x] Tested NA basin since 2020 against DEV DB (135 storms, 405 buffer polygons written successfully)
- [ ] Run SQL schema against target DB before first run
- [ ] Run full historical backfill once ocha-lens PR is merged and version bumped in requirements.txt