### PR TITLE
Add :30 WSP late-arrival retry to NHC pipeline cron

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -68,8 +68,18 @@ resources:
         git_provider: gitHub
         git_branch: ${var.git_branch}
 
+      # Fires at :00 AND :30 of every 3rd hour. The :30 run is a WSP
+      # late-arrival retry: NHC frequently publishes the cycle's WSP zip
+      # after the on-time :00 run, which then finds no WSP and skips it.
+      # Re-running the whole cascade 30 min later is fill-only, not a
+      # rebuild — every stage either short-circuits on an already-present
+      # issued_time (buffers, wsp-matched; the WSP-peek in nhc.py also
+      # skips the multi-MB re-download) or upserts identical rows for the
+      # same advisory (exposure). So the :30 run picks up late WSP without
+      # clobbering anything written on time. To force a rebuild, run with
+      # overwrite=true.
       schedule:
-        quartz_cron_expression: "0 0 0/3 * * ?"
+        quartz_cron_expression: "0 0,30 0/3 * * ?"
         timezone_id: UTC
         pause_status: UNPAUSED
 


### PR DESCRIPTION
## What

Change the `nhc_pipeline` schedule from `0 0 0/3 * * ?` to `0 0,30 0/3 * * ?` so the cascade fires at **both :00 and :30** of every 3rd hour.

## Why

NHC frequently publishes a cycle's WSP zip *after* the on-time :00 run, which then finds no WSP and skips it. The :30 run is a late-arrival retry that picks up WSP once it lands.

## Fill-only, not a rebuild

The :30 run re-runs the whole cascade but does **not** clobber anything written on time:

- Buffer / WSP-matched stages short-circuit on an already-present `issued_time`.
- The WSP-peek in `nhc.py` skips the multi-MB re-download when those rows are already in the DB.
- Exposure re-upserts identical rows for the same advisory (`if_exists="append"` + `postgres_upsert`).

Cost: the two track stages also re-run at :30 (track exposure recomputes the same rows — wasted compute, not wrong data). Single-job, single-schedule kept for simplicity rather than a separate retry job.

To force a rebuild instead, run with `overwrite=true`.

`databricks bundle validate -t dev` passes.