### PR TITLE
Bump ocha-lens to 0.5.0

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -135,10 +135,7 @@ resources:
               - "{{job.parameters.admin_level}}"
           libraries: &storm_libs
             - pypi: { package: "ocha-stratus" }
-            - pypi:
-                # Pinned to commit; bump when ocha-lens@wsp-exp-calc moves
-                # so DBX's library cache forces a reinstall.
-                package: "ocha-lens @ git+https://github.com/OCHA-DAP/ocha-lens.git@5c6123f"
+            - pypi: { package: "ocha-lens==0.5.0" }
             - pypi: { package: "python-dotenv" }
             - pypi: { package: "geopandas" }
             - pypi: { package: "rasterio" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ geoalchemy2==0.18.0
 pandas>=2.0.0
 numpy>=1.24.0
 ocha-stratus==0.1.4
-ocha-lens==0.4.2
+ocha-lens==0.5.0
 
 # Date handling
 python-dateutil>=2.8.2


### PR DESCRIPTION
Updates both repo `ocha-lens` pins to the new **0.5.0** release.

- `databricks.yml` — replaces the git-commit pin (`@5c6123f` on the unreleased `wsp-exp-calc` branch) with `ocha-lens==0.5.0`, and drops the now-stale "pinned to commit" comment.
- `requirements.txt` — `0.4.2` → `0.5.0` (0.4.2 lacked `calculate_wind_buffers_gdf` and the other wind-buffer/WSP APIs).

`databricks bundle validate -t dev` passes.

### Follow-up (not in this PR)
The legacy **"Run NHC"** DBX job (owner `adm.hker1`) still pins `ocha-lens==0.4.1` in the workspace and is failing on the missing import — it needs the same bump to `0.5.0` to go green.