### PR TITLE
Bump ocha-lens to 0.5.1

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -94,7 +94,7 @@ resources:
               - "{{job.parameters.admin_level}}"
           libraries: &storm_libs
             - pypi: { package: "ocha-stratus" }
-            - pypi: { package: "ocha-lens==0.5.0" }
+            - pypi: { package: "ocha-lens==0.5.1" }
             - pypi: { package: "python-dotenv" }
             - pypi: { package: "geopandas" }
             - pypi: { package: "rasterio" }
@@ -245,7 +245,7 @@ resources:
             # APIs (get_exposure_adm0/adm1, match_to_atcf, …). Matches the
             # pin on main / requirements.txt. Bump when a newer release adds
             # what we need.
-            - pypi: { package: "ocha-lens==0.5.0" }
+            - pypi: { package: "ocha-lens==0.5.1" }
             - pypi: { package: "python-dotenv" }
             - pypi: { package: "coloredlogs" }
             - pypi: { package: "tqdm" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ geoalchemy2==0.18.0
 pandas>=2.0.0
 numpy>=1.24.0
 ocha-stratus==0.1.7
-ocha-lens==0.5.0
+ocha-lens==0.5.1
 
 # Date handling
 python-dateutil>=2.8.2


### PR DESCRIPTION
Bumps all `ocha-lens` pins from `0.5.0` to **0.5.1**.

0.5.1 ships the realtime observed wind-radii backfill ([ocha-lens #48](https://github.com/OCHA-DAP/ocha-lens/pull/48)): `_extract_current_observation` no longer leaves `leadtime=0` wind radii null (it backfills them from the forecast advisory's analysis block), so realtime-ingested storms now produce **observed wind buffers** — fixing the gap where 2026 EP storms (Amanda/Boris/Cristina) had none.

- `databricks.yml` — both library anchors (`storm_libs`, `gdacs_libs`)
- `requirements.txt`

Verified `_parse_current_center_radii` is present in the `0.5.1` tag. `databricks bundle validate -t dev` passes.

### Follow-up (separate)
After merge + redeploy, backfill the 2026 storms so their observed buffers generate (storm data is in the dev DB).