### PR TITLE
Persist reviewer `note` into gdacs/adam FM lookups

### DIFF
--- a/scripts/build_adam_fm_lookup.py
+++ b/scripts/build_adam_fm_lookup.py
@@ -69,7 +69,7 @@ DB_TABLE = "adam_fm_lookup"
 LOOKUP_COLUMNS = [
     "iso3", "admin_level", "fm_pcode", "fm_name",
     "adam_admin_id", "adam_admin_name",
-    "iou", "caveat_kind", "caveat_note",
+    "iou", "caveat_kind", "caveat_note", "note",
 ]
 
 # Status values that produce a lookup row (others are excluded).
@@ -131,6 +131,7 @@ def build_adm0_row(
         "iou": None,
         "caveat_kind": POLICY_TO_KIND.get(policy_action),
         "caveat_note": policy_note or None,
+        "note": None,  # `note` is per-adm1-unit in the crosswalk; adm0 has none
     }
 
 
@@ -175,11 +176,17 @@ def emit_adm1_rows_for_country(
                      if pd.notna(c) and str(c).strip()),
                     None,
                 )
+                humrev_note = next(
+                    (str(c).strip() for c in g["note"]
+                     if pd.notna(c) and str(c).strip()),
+                    None,
+                ) if "note" in g.columns else None
                 rows.append(_build_adm1_row(
                     iso3, fm_pcode, fm_name,
                     adam_id=None, adam_name=None, iou=None,
                     caveat_kind="fm_adm1_only",
                     caveat_note=humrev_caveat or policy_note,
+                    note=humrev_note,
                 ))
             # else: FM silently disappears. The validator's coverage
             # check should have caught this; log a warning here too.
@@ -203,6 +210,7 @@ def emit_adm1_rows_for_country(
                 adam_id=None, adam_name=None, iou=None,
                 caveat_kind=STATUS_TO_KIND["fm_only"],
                 caveat_note=_caveat(chosen),
+                note=_note(chosen),
             ))
             continue
 
@@ -216,6 +224,7 @@ def emit_adm1_rows_for_country(
                 iou=r["iou"],
                 caveat_kind=STATUS_TO_KIND.get(r["status"]),
                 caveat_note=_caveat(r),
+                note=_note(r),
             ))
 
     return rows
@@ -224,7 +233,7 @@ def emit_adm1_rows_for_country(
 def _build_adm1_row(
     iso3, fm_pcode, fm_name,
     adam_id, adam_name, iou,
-    caveat_kind, caveat_note,
+    caveat_kind, caveat_note, note=None,
 ) -> dict:
     """Construct an adm1 lookup row dict."""
     # Coerce types — adam_admin_id is float in the crosswalk because
@@ -248,7 +257,17 @@ def _build_adm1_row(
         "iou": iou,
         "caveat_kind": caveat_kind,
         "caveat_note": caveat_note,
+        "note": note,
     }
+
+
+def _note(row: pd.Series) -> str | None:
+    """Reviewer's detailed `note` column (verbatim) — distinct from and
+    richer than the terse `caveat`. Blank/empty means no note."""
+    val = row.get("note")
+    if pd.notna(val) and str(val).strip():
+        return str(val).strip()
+    return None
 
 
 def _caveat(row: pd.Series) -> str | None:
@@ -354,6 +373,8 @@ def main() -> int:
     # them as Mac Roman) without leaking `﻿` into the first
     # column name on read.
     humrev = pd.read_csv(args.humrev, encoding="utf-8-sig")
+    if "note" not in humrev.columns:
+        humrev["note"] = None  # tolerate older crosswalks without the column
     logger.info("  %d rows across %d iso3s",
                 len(humrev), humrev["iso3"].nunique())
 

--- a/scripts/build_gdacs_fm_lookup.py
+++ b/scripts/build_gdacs_fm_lookup.py
@@ -71,7 +71,7 @@ DB_TABLE = "gdacs_fm_lookup"
 LOOKUP_COLUMNS = [
     "iso3", "admin_level", "fm_pcode", "fm_name",
     "gmi_admin", "gdacs_admin_name",
-    "caveat_kind", "caveat_note",
+    "caveat_kind", "caveat_note", "note",
 ]
 
 # Status values that produce a lookup row (others are excluded).
@@ -133,6 +133,7 @@ def build_adm0_row(
         "gdacs_admin_name": gdacs_country_name or iso3,
         "caveat_kind": POLICY_TO_KIND.get(policy_action),
         "caveat_note": policy_note or None,
+        "note": None,  # `note` is per-adm1-unit in the crosswalk; adm0 has none
     }
 
 
@@ -177,11 +178,17 @@ def emit_adm1_rows_for_country(
                      if pd.notna(c) and str(c).strip()),
                     None,
                 )
+                humrev_note = next(
+                    (str(c).strip() for c in g["note"]
+                     if pd.notna(c) and str(c).strip()),
+                    None,
+                ) if "note" in g.columns else None
                 rows.append(_build_adm1_row(
                     iso3, fm_pcode, fm_name,
                     gmi_admin=None, gdacs_admin_name=None,
                     caveat_kind="fm_adm1_only",
                     caveat_note=humrev_caveat or policy_note,
+                    note=humrev_note,
                 ))
             else:
                 logger.warning(
@@ -201,6 +208,7 @@ def emit_adm1_rows_for_country(
                 gmi_admin=None, gdacs_admin_name=None,
                 caveat_kind=STATUS_TO_KIND["fm_only"],
                 caveat_note=_caveat(chosen),
+                note=_note(chosen),
             ))
             continue
 
@@ -212,6 +220,7 @@ def emit_adm1_rows_for_country(
                 gdacs_admin_name=r["gdacs_admin_name"],
                 caveat_kind=STATUS_TO_KIND.get(r["status"]),
                 caveat_note=_caveat(r),
+                note=_note(r),
             ))
 
     return rows
@@ -220,7 +229,7 @@ def emit_adm1_rows_for_country(
 def _build_adm1_row(
     iso3, fm_pcode, fm_name,
     gmi_admin, gdacs_admin_name,
-    caveat_kind, caveat_note,
+    caveat_kind, caveat_note, note=None,
 ) -> dict:
     """Construct an adm1 lookup row dict."""
     if gmi_admin is not None and pd.notna(gmi_admin):
@@ -238,7 +247,17 @@ def _build_adm1_row(
         ),
         "caveat_kind": caveat_kind,
         "caveat_note": caveat_note,
+        "note": note,
     }
+
+
+def _note(row: pd.Series) -> str | None:
+    """Reviewer's detailed `note` column (verbatim) — distinct from and
+    richer than the terse `caveat`. Blank/empty means no note."""
+    val = row.get("note")
+    if pd.notna(val) and str(val).strip():
+        return str(val).strip()
+    return None
 
 
 def _caveat(row: pd.Series) -> str | None:
@@ -340,6 +359,8 @@ def main() -> int:
     logger.info("Loading humanreview crosswalk from %s", args.humrev)
     # utf-8-sig: transparently strips BOM if present
     humrev = pd.read_csv(args.humrev, encoding="utf-8-sig")
+    if "note" not in humrev.columns:
+        humrev["note"] = None  # tolerate older crosswalks without the column
     logger.info("  %d rows across %d iso3s",
                 len(humrev), humrev["iso3"].nunique())
 

--- a/src/schemas/sql/adam_fm_lookup.sql
+++ b/src/schemas/sql/adam_fm_lookup.sql
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS storms.adam_fm_lookup
     iou             DOUBLE PRECISION,
     caveat_kind     TEXT,
     caveat_note     TEXT,
+    note            TEXT,
     CONSTRAINT adam_fm_lookup_unique
         UNIQUE NULLS NOT DISTINCT (iso3, admin_level, fm_pcode, adam_admin_id)
 )
@@ -62,6 +63,8 @@ COMMENT ON COLUMN storms.adam_fm_lookup.caveat_kind IS
     'Match-quality / admin-level caveat. NULL means a clean 1:1 match. Observed values: aggregating_from_adam, fm_adm1_only, no_adam_at_adm1, country_only, needs_manual_mapping, aggregated_in_adam, no_adam_source.';
 COMMENT ON COLUMN storms.adam_fm_lookup.caveat_note IS
     'Free-text detail accompanying caveat_kind.';
+COMMENT ON COLUMN storms.adam_fm_lookup.note IS
+    'Reviewer''s detailed reasoning for this row (the human-review `note` column), distinct from and richer than the terse caveat_note. NULL when the reviewer left no extra note.';
 
 CREATE INDEX IF NOT EXISTS idx_adam_fm_lookup_admin_name
     ON storms.adam_fm_lookup (adam_admin_name) WHERE adam_admin_name IS NOT NULL;

--- a/src/schemas/sql/gdacs_fm_lookup.sql
+++ b/src/schemas/sql/gdacs_fm_lookup.sql
@@ -43,6 +43,7 @@ CREATE TABLE IF NOT EXISTS storms.gdacs_fm_lookup
     gdacs_admin_name TEXT,
     caveat_kind      TEXT,
     caveat_note      TEXT,
+    note             TEXT,
     CONSTRAINT gdacs_fm_lookup_unique
         UNIQUE NULLS NOT DISTINCT (iso3, admin_level, fm_pcode, gmi_admin)
 )
@@ -69,6 +70,8 @@ COMMENT ON COLUMN storms.gdacs_fm_lookup.caveat_kind IS
     'Match-quality / admin-level caveat. NULL means a clean 1:1 match. Observed values: fm_adm1_only, no_gdacs_at_adm1, aggregating_from_gdacs, country_only, aggregated_in_gdacs, needs_manual_mapping, no_fm_source.';
 COMMENT ON COLUMN storms.gdacs_fm_lookup.caveat_note IS
     'Free-text detail accompanying caveat_kind (e.g. which units were aggregated).';
+COMMENT ON COLUMN storms.gdacs_fm_lookup.note IS
+    'Reviewer''s detailed reasoning for this row (the human-review `note` column), distinct from and richer than the terse caveat_note. NULL when the reviewer left no extra note.';
 
 CREATE INDEX IF NOT EXISTS idx_gdacs_fm_lookup_gmi_admin
     ON storms.gdacs_fm_lookup (gmi_admin) WHERE gmi_admin IS NOT NULL;


### PR DESCRIPTION
## What

The human-review crosswalk carries a `note` column — the reviewer's **detailed** per-unit reasoning (CUB Artemisa's pre-2011 'La Habana' boundary, BHS City of Freeport's IoU asymmetry) — that is distinct from and richer than the terse `caveat`. The builders only projected `caveat`/`policy_note` into `caveat_note`, so `note` never reached the DB and was invisible to every downstream consumer.

## Changes

- Add `note TEXT` (+ `COMMENT`) to both `gdacs_fm_lookup` and `adam_fm_lookup` schemas.
- Thread the crosswalk `note` through both builders (per-row, fm_only-dedupe, and fm_adm1_only-fallback emit paths) via a `_note()` helper mirroring `_caveat()`.
- adm0 rows get `note=NULL`; defensive default if an older crosswalk lacks the column.

Additive and **non-breaking**: `caveat_note` is unchanged.

## Verification

Dev rebuilt (`init_db_*_lookup.py` + `build_*_lookup.py --write-db --mode dev`), 0 blocking validations:
- `gdacs_fm_lookup`: 786 rows, **25** with `note`
- `adam_fm_lookup`: 837 rows, **112** with `note`

## Follow-ups (out of scope here)

1. Notes on **non-emitted** rows aren't carried — suppressed `country_only`/`no_fm_source` countries (ANT, XIM) and skipped FMs (PRI). Would require surfacing notes on the adm0 row.
2. The source crosswalk `note` column has `→` **mojibake** (`'Üí`) worth a cleanup pass on the CSV.