### PR TITLE
Trigger Cuba Forecast Monitor after NHC ETL

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -31,6 +31,15 @@ variables:
   dev_cluster_id:
     description: Interactive cluster the GDACS/ADAM dev tasks run on
     default: "0604-214501-kq22m39c"   # zarno GDACS-ADAM dev (isolated lib env)
+  cuba_forecast_job_id:
+    description: >-
+      Job ID the post-ETL trigger fires (fire-and-forget). Empty string
+      => the trigger task no-ops. Defaults to the shared (un-prefixed)
+      Cuba Hurricane Forecast Monitor, which runs `main` and has no
+      schedule of its own — so every NHC deploy kicks the same canonical
+      monitor. Override per target only if a deploy must hit a different
+      one.
+    default: "527252598381643"   # Cuba Hurricane Forecast Monitor (shared, runs main)
 
 resources:
   jobs:
@@ -105,6 +114,22 @@ resources:
             - pypi: { package: "tqdm" }
             - pypi: { package: "geoalchemy2" }
             - pypi: { package: "databricks-sdk" }
+
+        # Fire-and-forget kick of the Cuba Forecast Monitor, right after
+        # ETL. Leaf task (nothing depends on it), parallel to
+        # tracks_processing. trigger_job.py never raises, so a failure to
+        # trigger — or in the monitor itself — cannot fail this run; the
+        # monitor stays fully independent of the storms pipeline.
+        - task_key: trigger_cuba_forecast
+          depends_on:
+            - task_key: etl
+          existing_cluster_id: ${var.existing_cluster_id}
+          spark_python_task:
+            python_file: databricks/trigger_job.py
+            source: GIT
+            parameters:
+              - "${var.cuba_forecast_job_id}"
+          libraries: *storm_libs
 
         - task_key: tracks_processing
           depends_on:

--- a/databricks/trigger_job.py
+++ b/databricks/trigger_job.py
@@ -1,0 +1,67 @@
+"""DBX task: fire-and-forget trigger for the Cuba Forecast Monitor.
+
+Added as a leaf task after the NHC ``etl`` stage. Its only job is to
+*start* a separate Databricks job (the Cuba Hurricane Forecast Monitor)
+and return immediately — without waiting for it, and without ever
+failing the NHC run.
+
+Isolation is the whole point: the monitor is meant to be independent of
+the storms pipeline, so a problem triggering it (or in the monitor
+itself) must not turn the NHC run red. Two things guarantee that:
+
+  * we call ``jobs.run_now``, which returns as soon as the run is
+    *queued* — it does not block until the monitor finishes, and we
+    never call ``.result()``; and
+  * we catch every exception and let the script end normally. We never
+    ``raise`` and never call ``sys.exit`` — DBX's exec context maps both
+    onto task failure (it treats even ``SystemExit(0)`` as failure; see
+    the note in dispatch_gdacs_adam.py). The only safe success signal is
+    to fall off the end of ``main``.
+
+Positional contract (mirrors the task ``parameters:`` in databricks.yml):
+    sys.argv[1] = job_id   # numeric Databricks job id, or "" to no-op
+
+An empty job_id is a deliberate no-op (logged, exits clean). That lets a
+target with no monitor wired up — e.g. prod, where no prod Cuba monitor
+exists yet — carry the task harmlessly until an id is filled in.
+"""
+
+import sys
+
+
+def _arg(i, default=""):
+    return sys.argv[i] if len(sys.argv) > i else default
+
+
+JOB_ID = _arg(1).strip()
+
+
+def main() -> None:
+    if not JOB_ID:
+        print(
+            "trigger_job.py: no job_id provided — nothing to trigger.",
+            flush=True,
+        )
+        return
+    try:
+        from databricks.sdk import WorkspaceClient
+
+        run = WorkspaceClient().jobs.run_now(job_id=int(JOB_ID))
+        # run_now returns once the run is queued; we intentionally do NOT
+        # call .result() — firing and forgetting is the contract.
+        run_id = getattr(run, "run_id", None)
+        print(
+            f"trigger_job.py: queued run for job_id={JOB_ID} "
+            f"(run_id={run_id}).",
+            flush=True,
+        )
+    except Exception as exc:  # noqa: BLE001 — never fail the NHC run
+        print(
+            f"trigger_job.py: could not trigger job_id={JOB_ID}: "
+            f"{exc!r}. Ignoring (isolated by design).",
+            flush=True,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a **fire-and-forget** task to the `nhc_pipeline` job that kicks off the **Cuba Hurricane Forecast Monitor** (`527252598381643`) right after the `etl` task.

## Why this shape

The monitor must be **independent of the storms pipeline** — if triggering it (or the monitor itself) fails, it must not affect the NHC run. So:

- **`databricks/trigger_job.py`** (new) calls `jobs.run_now(...)` and returns as soon as the run is *queued* — it never waits (`.result()` is not called) and **never raises / never `sys.exit`s**, so the NHC run stays green regardless. (DBX maps any `raise` *and* `SystemExit(0)` onto task failure — see the note in `dispatch_gdacs_adam.py`.)
- The new `trigger_cuba_forecast` task is a **leaf** (nothing depends on it), running parallel to `tracks_processing`, so it structurally can't block the DAG either.
- An empty `job_id` is a deliberate no-op (logged, exits clean).

## Target job

`cuba_forecast_job_id` defaults to `527252598381643` — the shared, un-prefixed `Cuba Hurricane Forecast Monitor`, which runs `main` and has **no schedule of its own** (built to be triggered externally). Same value for dev and prod targets.

## Deploy note (important)

The NHC job pulls its Python from GitHub at runtime (`git_source`, `git_branch` defaults to `main`). So **this must be on `main` before a deploy will find `trigger_job.py`** — merge first, then `databricks bundle deploy -t dev` under your account to wire the trigger into your `[dev adm_tdowning] NHC Pipeline` job (`583285176982712`).

Bundle validates on both `-t dev` and `-t prod`; `trigger_job.py` is ruff-clean and `py_compile`s.