### PR TITLE
Skip the :30 WSP-retry re-fire of the Cuba monitor trigger

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -129,6 +129,12 @@ resources:
             source: GIT
             parameters:
               - "${var.cuba_forecast_job_id}"
+              # Scheduled minute of this run (UTC, rounded down): the cron
+              # fires at :00 and :30; the :30 run is only a WSP late-arrival
+              # retry, so the monitor (needs tracks only, landed at :00) is
+              # skipped on it. Anything other than "30" fires (fail-open, so
+              # manual/ad-hoc runs still trigger). See issue #35.
+              - "{{job.trigger.time.minute}}"
           libraries: *storm_libs
 
         - task_key: tracks_processing

--- a/databricks/trigger_job.py
+++ b/databricks/trigger_job.py
@@ -19,11 +19,22 @@ itself) must not turn the NHC run red. Two things guarantee that:
     to fall off the end of ``main``.
 
 Positional contract (mirrors the task ``parameters:`` in databricks.yml):
-    sys.argv[1] = job_id   # numeric Databricks job id, or "" to no-op
+    sys.argv[1] = job_id            # numeric Databricks job id, or "" to no-op
+    sys.argv[2] = scheduled_minute  # this run's triggered minute (UTC), or ""
 
 An empty job_id is a deliberate no-op (logged, exits clean). That lets a
 target with no monitor wired up — e.g. prod, where no prod Cuba monitor
 exists yet — carry the task harmlessly until an id is filled in.
+
+``scheduled_minute`` gates the once-per-advisory behaviour (issue #35).
+``nhc_pipeline`` fires at :00 and :30 of every 3rd hour; the :30 run is a
+WSP late-arrival retry. The monitor only needs the forecast tracks, which
+land on the :00 run, so we skip the trigger when the run's scheduled minute
+is "30". Anything else fires — including manual/ad-hoc runs (whose minute is
+rarely exactly 30) and an unreadable value — i.e. fail-open: we never
+silently drop a trigger, we only ever skip the known-redundant :30 retry.
+The minute comes from ``{{job.trigger.time.minute}}`` (the *scheduled*
+time, not wall-clock), so a slow etl can't drift it out of the window.
 """
 
 import sys
@@ -34,12 +45,20 @@ def _arg(i, default=""):
 
 
 JOB_ID = _arg(1).strip()
+SCHEDULED_MINUTE = _arg(2).strip()
 
 
 def main() -> None:
     if not JOB_ID:
         print(
             "trigger_job.py: no job_id provided — nothing to trigger.",
+            flush=True,
+        )
+        return
+    if SCHEDULED_MINUTE == "30":
+        print(
+            "trigger_job.py: :30 WSP-retry run — tracks already landed at "
+            ":00, skipping cub trigger (issue #35).",
             flush=True,
         )
         return


### PR DESCRIPTION
Closes #35.

## What
`nhc_pipeline` fires at `:00` **and** `:30` of every 3rd hour (the `:30` run is a WSP late-arrival retry). Today `trigger_cuba_forecast` fires on **both**, so the Cuba forecast monitor runs ~16×/day — half redundant (~18-min ephemeral cluster each, for a no-op). This skips the `:30` re-fire.

## How
Gate `trigger_job.py` on the run's **scheduled minute**, passed as a new task param `{{job.trigger.time.minute}}`:

| Run | minute | result |
|---|---|---|
| `:00` scheduled | `0` | fires ✅ |
| `:30` WSP-retry | `30` | skips ⏭️ |
| manual / ad-hoc | (rarely `30`) | fires ✅ (fail-open) |
| value missing | `""` | fires ✅ (fail-open) |

Uses `{{job.trigger.time.minute}}` (the *triggered* time, rounded down) not wall-clock, so a slow `etl` can't drift the trigger task out of the window. The never-raise / fire-and-forget contract is unchanged.

## Why this approach (vs the issue's preferred Option A)
#35 preferred emitting a `tracks_changed` flag from `etl` — shared code feeding every downstream task. The requirement here was **zero effect on anything but the cub trigger**, so this is deliberately #35's "Option C" (schedule gate), hardened by using the *scheduled* time to remove the fragility the issue flagged. Touches **only** `databricks.yml` (the trigger task) and `databricks/trigger_job.py`; `nhc.py` / `run_pipeline.py` / `dispatch.py` untouched.

## One relaxed acceptance criterion
A brand-new advisory first appearing *only* on a `:30` run won't trigger until the next `:00` (~3h). The `:30` retry exists precisely because NHC publish timing is irregular, so this window is real but rare — acceptable for a not-urgent cost optimization. The no-delay fix is #35's Option A, at the cost of touching shared `etl` code.

## Deploy note (needs redeploy — both targets)
The new param lives in the **job definition**, so it takes effect only after `databricks bundle deploy`. Both NHC deployments need it:
- **prod** — `NHC Pipeline` (`959161297191654`, run_as adm.tdowning) is now live and is the deployment **actually firing the cub monitor** — the important one.
- **dev** — `[dev adm_tdowning] NHC Pipeline` (`583…`).

Deploy updates the deployer's own copy, so **Tristan redeploys `-t prod` and `-t dev`** after merge. No broken in-between state: until merge + redeploy land, the trigger fail-opens and behaves exactly as today.

⚠️ Collides with #37 (same `trigger_cuba_forecast` block). Suggested order: **merge this (#36) first, then #37 rebases + re-validates** `-t dev`/`-t prod`.

Bundle validates on `-t dev` and `-t prod`; `trigger_job.py` is ruff-clean and `py_compile`s.