### PR TITLE
NHC prod: ephemeral Job Compute cluster + run as adm.tdowning (DEV DB during cutover)

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -47,7 +47,8 @@ resources:
     # ===================================================================
     # NHC pipeline — 5 chained tasks (etl → tracks_processing →
     # {tracks_exposure, wsp_processing → wsp_exposure}). Dispatches via
-    # databricks/dispatch.py. Runs on the interactive cluster.
+    # databricks/dispatch.py. Compute is supplied per target below
+    # (dev: personal interactive cluster; prod: ephemeral Job Compute).
     # ===================================================================
     nhc_pipeline:
       name: NHC Pipeline
@@ -87,7 +88,6 @@ resources:
 
       tasks:
         - task_key: etl
-          existing_cluster_id: ${var.existing_cluster_id}
           spark_python_task:
             python_file: databricks/dispatch.py
             source: GIT
@@ -123,7 +123,6 @@ resources:
         - task_key: trigger_cuba_forecast
           depends_on:
             - task_key: etl
-          existing_cluster_id: ${var.existing_cluster_id}
           spark_python_task:
             python_file: databricks/trigger_job.py
             source: GIT
@@ -134,7 +133,6 @@ resources:
         - task_key: tracks_processing
           depends_on:
             - task_key: etl
-          existing_cluster_id: ${var.existing_cluster_id}
           spark_python_task:
             python_file: databricks/dispatch.py
             source: GIT
@@ -153,7 +151,6 @@ resources:
         - task_key: tracks_exposure
           depends_on:
             - task_key: tracks_processing
-          existing_cluster_id: ${var.existing_cluster_id}
           spark_python_task:
             python_file: databricks/dispatch.py
             source: GIT
@@ -172,7 +169,6 @@ resources:
         - task_key: wsp_processing
           depends_on:
             - task_key: tracks_processing
-          existing_cluster_id: ${var.existing_cluster_id}
           spark_python_task:
             python_file: databricks/dispatch.py
             source: GIT
@@ -191,7 +187,6 @@ resources:
         - task_key: wsp_exposure
           depends_on:
             - task_key: wsp_processing
-          existing_cluster_id: ${var.existing_cluster_id}
           spark_python_task:
             python_file: databricks/dispatch.py
             source: GIT
@@ -320,10 +315,24 @@ targets:
       profile: DEFAULT
     variables:
       mode: dev
-    # NHC tasks use existing_cluster_id (inline). GDACS/ADAM dev runs on
-    # the dedicated dev cluster (isolated lib env).
+    # NHC dev runs on the personal interactive cluster; GDACS/ADAM dev runs
+    # on the dedicated dev cluster (isolated lib env).
     resources:
       jobs:
+        nhc_pipeline:
+          tasks:
+            - task_key: etl
+              existing_cluster_id: ${var.existing_cluster_id}
+            - task_key: trigger_cuba_forecast
+              existing_cluster_id: ${var.existing_cluster_id}
+            - task_key: tracks_processing
+              existing_cluster_id: ${var.existing_cluster_id}
+            - task_key: tracks_exposure
+              existing_cluster_id: ${var.existing_cluster_id}
+            - task_key: wsp_processing
+              existing_cluster_id: ${var.existing_cluster_id}
+            - task_key: wsp_exposure
+              existing_cluster_id: ${var.existing_cluster_id}
         gdacs_adam_pipeline:
           tasks:
             - task_key: gdacs
@@ -338,13 +347,48 @@ targets:
     workspace:
       profile: DEFAULT
       # production mode requires an explicit root_path.
-      root_path: /Workspace/Users/adm.zarno1@global.un.org/.bundle/${bundle.name}/${bundle.target}
+      root_path: /Workspace/Users/adm.tdowning@global.un.org/.bundle/${bundle.name}/${bundle.target}
+    # Job runs as the deploying user (adm.tdowning), who holds Manage Run on
+    # the Cuba monitor — so the post-ETL trigger fires. Set explicitly for
+    # production mode and to pin the SINGLE_USER job cluster's identity.
+    run_as:
+      user_name: adm.tdowning@global.un.org
     variables:
-      mode: prod
-    # GDACS/ADAM prod runs on an ephemeral single-node job cluster.
-    # (NHC prod keeps its inline existing_cluster_id.)
+      # TEMPORARY: the prod deployment reads/writes the DEV DB during cutover.
+      # Flip to `prod` once we're ready to write prod tables. NB: this also
+      # routes GDACS/ADAM prod at the DEV DB while set to dev.
+      mode: dev
+    # NHC prod runs on an ephemeral Job Compute cluster (policy bakes in the
+    # dsci DB/blob secrets). GDACS/ADAM prod runs on its own ephemeral
+    # single-node job cluster.
     resources:
       jobs:
+        nhc_pipeline:
+          job_clusters:
+            - job_cluster_key: nhc_cluster
+              new_cluster:
+                # Job Compute policy (000C79D951EAF0D6): fixes cluster_type=job,
+                # num_workers=1, STANDARD engine, and injects all dsci secret
+                # env vars (DEV+PROD DB/blob), so no spark_env_vars block needed.
+                policy_id: "000C79D951EAF0D6"
+                apply_policy_default_values: true
+                spark_version: "18.2.x-scala2.13"
+                node_type_id: "Standard_DS3_v2"
+                num_workers: 1
+                data_security_mode: SINGLE_USER
+          tasks:
+            - task_key: etl
+              job_cluster_key: nhc_cluster
+            - task_key: trigger_cuba_forecast
+              job_cluster_key: nhc_cluster
+            - task_key: tracks_processing
+              job_cluster_key: nhc_cluster
+            - task_key: tracks_exposure
+              job_cluster_key: nhc_cluster
+            - task_key: wsp_processing
+              job_cluster_key: nhc_cluster
+            - task_key: wsp_exposure
+              job_cluster_key: nhc_cluster
         gdacs_adam_pipeline:
           job_clusters:
             - job_cluster_key: gdacs_adam_cluster


### PR DESCRIPTION
## What

Two changes to the **NHC pipeline** bundle config (`databricks.yml`):

### 1. Job Compute instead of the personal all-purpose cluster
NHC tasks were pinned to `existing_cluster_id` = "Tristan Downing's Personal Compute Cluster". Restructured NHC compute to be **per-target** (same pattern GDACS/ADAM already uses): base tasks carry no cluster, then:
- **dev** — keeps the personal interactive cluster (unchanged behavior).
- **prod** — ephemeral `nhc_cluster` job cluster on the **Job Compute policy** (`000C79D951EAF0D6`). The policy fixes `cluster_type=job`, `num_workers=1`, `STANDARD` engine, and injects all `dsci` DB+blob secret env vars — so no `spark_env_vars` block is needed. Fresh env per run ends the `ocha-lens` `ERROR_DUPLICATE_INSTALLATION` accumulation that required manual cluster cleanup on each pin bump.

### 2. Flip prod to adm.tdowning ownership, on the DEV DB
- `root_path` → `adm.tdowning`'s workspace (was `adm.zarno1`).
- Explicit `run_as: adm.tdowning` — holds Manage Run on the Cuba monitor, so the post-ETL trigger fires; also pins the `SINGLE_USER` job cluster's identity.
- **prod `mode` var stays `dev`** so the prod deployment reads/writes the **DEV DB** during cutover. Flip to `prod` later to write prod tables. ⚠️ Note this also routes **GDACS/ADAM prod** at the DEV DB while set to `dev`.

## Validation

`databricks bundle validate` passes on both `-t dev` and `-t prod`. Resolved compute confirmed: dev NHC → personal cluster; prod NHC → `nhc_cluster` (policy, SINGLE_USER, run_as adm.tdowning), `mode=dev` on both.

## Deploy / cutover notes (not done in this PR)
- Deploying `-t prod` creates **new** unprefixed `NHC Pipeline` + `GDACS/ADAM Pipeline` jobs under adm.tdowning, with **UNPAUSED** 3h schedules.
- The existing `[dev adm_tdowning]` NHC job will still be running on the same schedule against the same DEV DB → **pause/destroy the dev NHC job** when cutting over to avoid double-running.